### PR TITLE
Release 0.2.1: iOS plugin-lifecycle composition fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.2.1
+
+* iOS: scope foreground presentation to Klaviyo-owned pushes and join the standard `FlutterPlugin` lifecycle for `userNotificationCenter:willPresent:` / `:didReceive:` instead of claiming `UNUserNotificationCenter.delegate`. Composes cleanly with `flutter_local_notifications`, `firebase_messaging`, and host `AppDelegate` notification handlers.
+
 ## 0.2.0
 
 * Add individual set profile attributes methods, thanks @Lo4D

--- a/README.md
+++ b/README.md
@@ -143,6 +143,14 @@ if (token != null && token.isNotEmpty) {
     }
 ```
 
+The plugin participates in the standard `FlutterPlugin` lifecycle on iOS:
+`FlutterAppDelegate` keeps the `UNUserNotificationCenter` delegate slot and
+dispatches `willPresent` / `didReceive` to every registered plugin.
+Klaviyo-owned foreground pushes are presented with `.list`/`.banner` on
+iOS 14+ (and `.alert` otherwise); other notifications are left for the host
+`AppDelegate` and other plugins (`flutter_local_notifications`,
+`firebase_messaging`, etc.) to handle in the same dispatch chain.
+
 Any users that enable/accept push notifications from your app now will be eligible to receive your custom notifications.
 
 To read more about sending push notifications, check out our additional push notification guides.

--- a/ios/Classes/KlaviyoFlutterPlugin.swift
+++ b/ios/Classes/KlaviyoFlutterPlugin.swift
@@ -46,34 +46,30 @@ public class KlaviyoFlutterPlugin: NSObject, FlutterPlugin,
             binaryMessenger: messenger
         )
         let instance = KlaviyoFlutterPlugin()
-
-        if #available(OSX 10.14, *) {
-            let center = UNUserNotificationCenter.current()
-            center.delegate = instance
-        }
-
         registrar.addMethodCallDelegate(instance, channel: channel)
+        registrar.addApplicationDelegate(instance)
     }
 
-    // below method will be called when the user interacts with the push notification
+    // FlutterAppDelegate dispatches userNotificationCenter:didReceive: to every
+    // registered FlutterPlugin via FlutterPluginAppLifeCycleDelegate. The
+    // convention is to handle notifications this plugin owns and stay silent
+    // (return without calling completionHandler) for ones it doesn't, letting
+    // another plugin in the chain claim them.
     public func userNotificationCenter(
         _ center: UNUserNotificationCenter,
         didReceive response: UNNotificationResponse,
         withCompletionHandler completionHandler: @escaping () -> Void
     ) {
-
-        // If this notification is Klaviyo's notification we'll handle it
-        // else pass it on to the next push notification service to which it may belong
-        let handled = KlaviyoSDK().handle(
+        _ = KlaviyoSDK().handle(
             notificationResponse: response,
             withCompletionHandler: completionHandler
         )
-        if !handled {
-            completionHandler()
-        }
     }
 
-    // below method is called when the app receives push notifications when the app is the foreground
+    // Same plugin-lifecycle convention applies here: present banner options for
+    // Klaviyo-owned foreground pushes, return silently for everything else so
+    // other plugins (flutter_local_notifications, firebase_messaging, etc.) and
+    // the host AppDelegate can decide.
     public func userNotificationCenter(
         _ center: UNUserNotificationCenter,
         willPresent notification: UNNotification,
@@ -81,6 +77,7 @@ public class KlaviyoFlutterPlugin: NSObject, FlutterPlugin,
             UNNotificationPresentationOptions
         ) -> Void
     ) {
+        guard notification.isKlaviyoNotification else { return }
         var options: UNNotificationPresentationOptions = [.alert]
         if #available(iOS 14.0, *) {
             options = [.list, .banner]
@@ -436,6 +433,21 @@ public class KlaviyoFlutterPlugin: NSObject, FlutterPlugin,
 extension String {
     var toDouble: Double {
         return Double(self) ?? 0.0
+    }
+}
+
+extension UNNotification {
+    // Mirrors KlaviyoSwift's internal predicate for Klaviyo-owned pushes
+    // (the same `body._k` check used by `KlaviyoSDK().handle(notificationResponse:)`,
+    // and exposed publicly on `UNNotificationResponse.isKlaviyoNotification` in
+    // newer SDK versions). Replicated locally because no SDK helper takes a
+    // `UNNotification`; swap if one is added upstream.
+    var isKlaviyoNotification: Bool {
+        guard
+            let userInfo = request.content.userInfo as? [String: Any],
+            let body = userInfo["body"] as? [String: Any]
+        else { return false }
+        return body["_k"] != nil
     }
 }
 

--- a/ios/klaviyo_flutter.podspec
+++ b/ios/klaviyo_flutter.podspec
@@ -3,7 +3,7 @@
 #
 Pod::Spec.new do |s|
   s.name             = 'klaviyo_flutter'
-  s.version          = '0.1.0'
+  s.version          = '0.2.1'
   s.summary          = 'Klaviyo integration for Flutter'
   s.description      = <<-DESC
 A new flutter plugin project.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: klaviyo_flutter
 description: Flutter plugin for Klaviyo integration. Provides push messaging
   and Klaviyo analitics services
-version: 0.2.0
+version: 0.2.1
 homepage: https://github.com/drybnikov/klaviyo_flutter
 
 environment:


### PR DESCRIPTION
## Summary

- Stop hijacking iOS foreground notification presentation. The plugin no longer claims `UNUserNotificationCenter.delegate`; it joins the standard `FlutterPlugin` lifecycle via `addApplicationDelegate`, identical to `firebase_messaging` and `flutter_local_notifications`.
- `willPresent` presents `[.list, .banner]` (or `[.alert]` pre-iOS-14) only for Klaviyo-owned pushes and returns silently for everything else, so other notification handling in the dispatch chain stays in control.
- `didReceive` lets `KlaviyoSDK().handle(notificationResponse:)` claim what it owns and stays silent otherwise; open-tracking is unchanged.
- Catches the iOS podspec up from 0.1.0 to match pubspec at 0.2.1.

## Why

The previous unconditional `completionHandler([.list, .banner])` in `willPresent`, combined with the plugin grabbing the global delegate slot at registration, hijacked other push providers (FCM, custom AppDelegate handlers) and caused double-banners in apps that re-display foreground pushes via `flutter_local_notifications`.

## Approach

KlaviyoSwift identifies its own pushes via `userInfo["body"]?["_k"] != nil` and exposes that publicly on `UNNotificationResponse.isKlaviyoNotification` in newer SDK versions, but no equivalent helper takes a `UNNotification`. A small `extension UNNotification.isKlaviyoNotification` replicates the check locally with a comment flagging it as a swap point if the SDK adds one.

## Compatibility

- KlaviyoSwift pin (`~> 4.2.1`) and iOS deployment target (13.0) unchanged.
- No Dart API changes, no new config flags, no Podfile changes for consumers.
- Klaviyo-owned foreground pushes get the same options as before; tap-time open-tracking is unchanged.

## Test plan

- [x] Plugin scheme builds clean (xcodebuild simulator Debug).
- [x] Foreground non-Klaviyo notification (no `body._k`) does not crash, no recursion through `FlutterPluginAppLifeCycleDelegate`.
- [x] Foreground Klaviyo push displays banner.
- [x] Tap on Klaviyo push fires `\$opened_push` in Klaviyo dashboard.
- [x] `flutter_local_notifications` foreground re-display with `presentBanner: true` shows banner.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Modified iOS notification handling to support compatibility with flutter_local_notifications, firebase_messaging, and host AppDelegate notification handlers.
  * Updated iOS foreground notification presentation behavior.

* **Documentation**
  * Added iOS push notification handling flow documentation to README.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->